### PR TITLE
 Make default target to build in release mode on current platform 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ targets = x86_64-unknown-linux-gnu \
 #		  ^ Potential bug in cross, openssl does not compile for wasm for some
 #		  reason.
 
+default :
+	cargo build --release
+	@echo Release binary: target/release/dirble
+
 help :
 	echo "Run 'make release' to make all targets"
 	echo "To build for just one platform then run 'make <target>'"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ With listable directory scraping enabled:
 
 # Building from source
 
-To build on your current platform, ensure cargo is installed and then run `cargo build --release`.
+To build on your current platform, ensure cargo is installed and then run `cargo build --release`. Alternatively, running `make` will build the binary in release mode (internally running `cargo build --release`).
 
 To cross-compile for 32- and 64-bit Linux and Windows targets, there is a handy makefile. `make release` will build for all four targets using `cross`. This depends on having cross and docker installed (`cargo install cross`).
 


### PR DESCRIPTION
Previously the default action when make was called was to print some help text. Intuitively, the default action for make should be to compile the program for the current platform, which this PR implements.