### PR TITLE
Add a Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM rust:latest as cargo-build
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update
+RUN apt-get install libssl-dev -y
+
+WORKDIR /usr/src/dirble
+COPY . .
+
+RUN cargo build --release
+
+FROM debian:stretch
+
+WORKDIR /home/dirble
+
+COPY --from=cargo-build /usr/src/dirble/target/release/dirble .
+COPY --from=cargo-build /usr/src/dirble/dirble_wordlist.txt .
+COPY --from=cargo-build /usr/src/dirble/wordlists/* extensions/
+
+RUN apt-get update && apt-get install -y \
+    libcurl4-openssl-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+ENTRYPOINT ["./dirble"]
+CMD []


### PR DESCRIPTION
See title. This PR intends to add a Dockerfile to dirble, I've set it up to automatically embed the `dirble_wordlist.txt` file and `wordlists` folder within the container, if end users want to alter these files they can provide their own by using the `-v` argument to set up volume mounts.

[After merging this PR i would suggest setting up either manual, or automated Docker hub builds](https://docs.docker.com/docker-hub/builds/) so that end-users can just run `docker run nccgroup/dirble`

# Usage

```
docker build -t nccgroup/dirble .
docker run --rm nccgroup/dirble https://example.com
```