### PR TITLE
Improved serialisation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,6 +139,8 @@ dependencies = [
  "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_test 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+ "simple_xml_serialize 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "simple_xml_serialize_macro 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -571,6 +573,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "simple_xml_serialize"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "simple_xml_serialize_macro"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.37 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "siphasher"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -820,6 +836,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)" = "46a3223d0c9ba936b61c0d2e3e559e3217dbfb8d65d06d26e8b3c25de38bae3e"
 "checksum serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)" = "5a23aa71d4a4d43fdbfaac00eff68ba8a06a51759a89ac3304323e800c4dd40d"
 "checksum serde_test 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)" = "d53757b8e67389a8f201b23621d40b708c7cd740c7c084bf6d7c1bf1bd840e97"
+"checksum simple_xml_serialize 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cd3f759e6c350727b20ec0de5c82b5e3058f5b967dace4c12cb77c64e0caa9e1"
+"checksum simple_xml_serialize_macro 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "96c88083b952d9e4efa3d2bdf6d95ba6acdbbdd72e160d72b2b63a5d29bf3098"
 "checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 "checksum socket2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c4d11a52082057d87cb5caa31ad812f4504b97ab44732cd8359df2e9ff9f48e7"
 "checksum string_cache 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "413fc7852aeeb5472f1986ef755f561ddf0c789d3d796e65f0b6fe293ecd4ef8"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -136,6 +136,9 @@ dependencies = [
  "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "select 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_test 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -220,6 +223,11 @@ dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "itoa"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "kernel32-sys"
@@ -504,6 +512,11 @@ version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "ryu"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "schannel"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -525,6 +538,37 @@ dependencies = [
 name = "serde"
 version = "1.0.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.37 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ryu 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_test"
+version = "1.0.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "siphasher"
@@ -586,6 +630,16 @@ dependencies = [
  "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
+version = "0.15.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -722,6 +776,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fuchsia-cprng 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 "checksum futf 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "7c9c1ce3fa9336301af935ab852c437817d14cd33690446569392e65170aac3b"
 "checksum html5ever 0.18.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a49d5001dd1bddf042ea41ed4e0a671d50b1bf187e66b349d7ec613bdce4ad90"
+"checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
 "checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
@@ -758,9 +813,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum redox_syscall 0.1.51 (registry+https://github.com/rust-lang/crates.io-index)" = "423e376fffca3dfa06c9e9790a9ccd282fafb3cc6e6397d01dbf64f9bacc6b85"
 "checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
+"checksum ryu 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "b96a9549dc8d48f2c283938303c4b5a77aa29bfbc5b54b084fb1630408899a8f"
 "checksum schannel 0.1.14 (registry+https://github.com/rust-lang/crates.io-index)" = "0e1a231dc10abf6749cfa5d7767f25888d484201accbd919b66ab5413c502d56"
 "checksum select 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7004292887d0a030e29abda3ae1b63a577c96a17e25d74eaa1952503e6c1c946"
 "checksum serde 1.0.89 (registry+https://github.com/rust-lang/crates.io-index)" = "92514fb95f900c9b5126e32d020f5c6d40564c27a5ea6d1d7d9f157a96623560"
+"checksum serde_derive 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)" = "46a3223d0c9ba936b61c0d2e3e559e3217dbfb8d65d06d26e8b3c25de38bae3e"
+"checksum serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)" = "5a23aa71d4a4d43fdbfaac00eff68ba8a06a51759a89ac3304323e800c4dd40d"
+"checksum serde_test 1.0.92 (registry+https://github.com/rust-lang/crates.io-index)" = "d53757b8e67389a8f201b23621d40b708c7cd740c7c084bf6d7c1bf1bd840e97"
 "checksum siphasher 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "0b8de496cf83d4ed58b6be86c3a275b8602f6ffe98d3024a869e124147a9a3ac"
 "checksum socket2 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "c4d11a52082057d87cb5caa31ad812f4504b97ab44732cd8359df2e9ff9f48e7"
 "checksum string_cache 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "413fc7852aeeb5472f1986ef755f561ddf0c789d3d796e65f0b6fe293ecd4ef8"
@@ -768,6 +827,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum string_cache_shared 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b1884d1bc09741d466d9b14e6d37ac89d6909cbcac41dd9ae982d4d063bbedfc"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
+"checksum syn 0.15.37 (registry+https://github.com/rust-lang/crates.io-index)" = "e11410033fd5cf69a1cf2084604e011190c56f11e08ffc53df880f5f65f1c6e4"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum tendril 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1b72f8e2f5b73b65c315b1a70c730f24b9d7a25f39e98de8acbe2bb795caea"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,6 @@ encoding = "0.2.33"
 atty = "0.2.11"
 colored = "1.7"
 rand = "0.6.5"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+serde_test = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,5 @@ rand = "0.6.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_test = "1.0"
+simple_xml_serialize = "0.2.1"
+simple_xml_serialize_macro = "0.2.1"

--- a/schemas/dirble_xml_schema.xsd
+++ b/schemas/dirble_xml_schema.xsd
@@ -1,22 +1,25 @@
-<?xml version = "1.0" encoding = "UTF-8"?>
-<xs:schema xmlns:xs = "http://www.w3.org/2001/XMLSchema">
-   <xs:element name = "dirble_scan">
-      <xs:complexType>
-          <xs:choice maxOccurs="unbounded" minOccurs="0">
-            <xs:element name="file">
-                <xs:complexType>
-                    <xs:sequence>
-                        <xs:element name = "status_code" type = "xs:int" />
-                        <xs:element name = "size" type = "xs:string" />
-                        <xs:element name = "is_directory" type = "xs:boolean" />
-                        <xs:element name = "is_listable" type = "xs:boolean" />
-                        <xs:element name = "found_from_listable" type = "xs:boolean" />
-                        <xs:element name = "redirect_url" type = "xs:string" />
-                    </xs:sequence>
-                    <xs:attribute name="url" type="xs:string" use="required" />
-                </xs:complexType>
-             </xs:element>
-         </xs:choice>
-      </xs:complexType>
-   </xs:element>
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+  <xs:element name="dirble_scan">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="path" maxOccurs="unbounded" minOccurs="0">
+          <xs:complexType>
+            <xs:simpleContent>
+              <xs:extension base="xs:string">
+                <xs:attribute type="xs:anyURI" name="url" />
+                <xs:attribute type="xs:int" name="code" />
+                <xs:attribute type="xs:int" name="content_len"/>
+                <xs:attribute type="xs:string" name="is_directory"/>
+                <xs:attribute type="xs:string" name="is_listable"/>
+                <xs:attribute type="xs:string" name="redirect_url"/>
+                <xs:attribute type="xs:string" name="found_from_listable"/>
+              </xs:extension>
+            </xs:simpleContent>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
 </xs:schema>
+
+

--- a/src/output_format.rs
+++ b/src/output_format.rs
@@ -18,6 +18,7 @@
 use crate::request::RequestResponse;
 use colored::*;
 use serde_json;
+use simple_xml_serialize::XMLElement;
 
 #[cfg(test)]
 mod tests;
@@ -96,21 +97,7 @@ pub fn output_suffix(response: &RequestResponse, color: bool) -> String {
 
 #[inline]
 pub fn output_xml(response: &RequestResponse) -> String {
-    format!("<file url=\"{}\">
-    <status_code>{}</status_code>
-    <size>{}</size>
-    <is_directory>{}</is_directory>
-    <is_listable>{}</is_listable>
-    <found_from_listable>{}</found_from_listable>
-    <redirect_url>{}</redirect_url>
-</file>\n", 
-    response.url,
-    response.code,
-    response.content_len,
-    response.is_directory,
-    response.is_listable,
-    response.found_from_listable,
-    response.redirect_url)
+    format!("{}\n", XMLElement::from(response).to_string())
 }
 
 #[inline]

--- a/src/output_format.rs
+++ b/src/output_format.rs
@@ -17,6 +17,7 @@
 
 use crate::request::RequestResponse;
 use colored::*;
+use serde_json;
 
 #[cfg(test)]
 mod tests;
@@ -114,21 +115,5 @@ pub fn output_xml(response: &RequestResponse) -> String {
 
 #[inline]
 pub fn output_json(response: &RequestResponse) -> String {
-
-    format!("{{\
-        \"url\": \"{}\", \
-        \"code\": {}, \
-        \"size\": {}, \
-        \"is_directory\": {}, \
-        \"is_listable\": {}, \
-        \"found_from_listable\": {}, \
-        \"redirect_url\": \"{}\"\
-        }}",
-        response.url,
-        response.code,
-        response.content_len,
-        response.is_directory,
-        response.is_listable,
-        response.found_from_listable,
-        response.redirect_url)
+    serde_json::to_string(response).unwrap()
 }

--- a/src/output_format/tests.rs
+++ b/src/output_format/tests.rs
@@ -178,15 +178,15 @@ fn check_output_xml() {
     // produced by the XML formatter.
     assert_eq!(
         super::output_xml(&req_response),
-        "<file url=\"http://example.com\">
-    <status_code>204</status_code>
-    <size>345</size>
-    <is_directory>false</is_directory>
-    <is_listable>false</is_listable>
-    <found_from_listable>true</found_from_listable>
-    <redirect_url>https://example.org</redirect_url>
-</file>
-",
+        "<path \
+            url=\"http://example.com\" \
+            code=\"204\" \
+            content_len=\"345\" \
+            is_directory=\"false\" \
+            is_listable=\"false\" \
+            redirect_url=\"https://example.org\" \
+            found_from_listable=\"true\"\
+        />\n",
         "XML format invalid");
 }
 

--- a/src/output_format/tests.rs
+++ b/src/output_format/tests.rs
@@ -20,6 +20,8 @@
 // relies on the indented string having the correct number of leading
 // spaces.
 
+use serde_test::{Token, assert_tokens};
+
 #[test]
 fn check_output_indentation() {
     //   super::output_indentation produces a number of spaces based on
@@ -199,25 +201,37 @@ fn check_output_json() {
         content_len: 350,
         is_directory: false,
         is_listable: true,
-        found_from_listable: false,
         redirect_url: "https://example.org".into(),
+        found_from_listable: false,
         parent_depth: 0
     };
-    let json = super::output_json(&req_response);
 
-    assert_eq!(
-        json,
-        "{\
-        \"url\": \"http://example.com\", \
-            \"code\": 200, \
-            \"size\": 350, \
-            \"is_directory\": false, \
-            \"is_listable\": true, \
-            \"found_from_listable\": false, \
-            \"redirect_url\": \"https://example.org\"\
-            }\
-            ",
-            "JSON output appears invalid!");
+    assert_tokens(&req_response, &[
+                  Token::Struct{ len: 7, name: "RequestResponse" },
+
+                  Token::String("url"),
+                  Token::String("http://example.com"),
+
+                  Token::String("code"),
+                  Token::U32(200),
+
+                  Token::String("size"),
+                  Token::U64(350),
+
+                  Token::String("is_directory"),
+                  Token::Bool(false),
+
+                  Token::String("is_listable"),
+                  Token::Bool(true),
+
+                  Token::String("redirect_url"),
+                  Token::String("https://example.org"),
+
+                  Token::String("found_from_listable"),
+                  Token::Bool(false),
+
+                  Token::StructEnd,
+    ]);
 }
 
 #[inline]

--- a/src/request.rs
+++ b/src/request.rs
@@ -23,6 +23,8 @@ use percent_encoding::percent_decode;
 extern crate curl;
 use curl::easy::{Easy2, Handler, WriteError};
 use crate::content_parse;
+//use serde::ser::{Serialize, Serializer, SerializeStruct};
+use serde::{Serialize, Deserialize};
 
 pub struct Collector
 {
@@ -48,15 +50,17 @@ impl Handler for Collector {
 
 // Struct which contains information about a response
 // This is sent back to the main thread
-#[derive(Clone)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct RequestResponse {
     pub url: String,
     pub code: u32,
+#[serde(rename = "size")]
     pub content_len: usize,
     pub is_directory: bool,
     pub is_listable: bool,
     pub redirect_url: String,
     pub found_from_listable: bool,
+#[serde(skip)]
     pub parent_depth: u32
 }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -23,8 +23,9 @@ use percent_encoding::percent_decode;
 extern crate curl;
 use curl::easy::{Easy2, Handler, WriteError};
 use crate::content_parse;
-//use serde::ser::{Serialize, Serializer, SerializeStruct};
 use serde::{Serialize, Deserialize};
+use simple_xml_serialize::XMLElement;
+use simple_xml_serialize_macro::xml_element;
 
 pub struct Collector
 {
@@ -50,15 +51,23 @@ impl Handler for Collector {
 
 // Struct which contains information about a response
 // This is sent back to the main thread
+#[xml_element("path")]
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
 pub struct RequestResponse {
+#[sxs_type_attr]
     pub url: String,
+#[sxs_type_attr]
     pub code: u32,
+#[sxs_type_attr]
 #[serde(rename = "size")]
     pub content_len: usize,
+#[sxs_type_attr]
     pub is_directory: bool,
+#[sxs_type_attr]
     pub is_listable: bool,
+#[sxs_type_attr]
     pub redirect_url: String,
+#[sxs_type_attr]
     pub found_from_listable: bool,
 #[serde(skip)]
     pub parent_depth: u32


### PR DESCRIPTION
Use the Serde and simple_xml_serialize crates to safely serialise the RequestResponse as JSON and XML.

Fixes #22 