### PR TITLE
Improved searching for the default wordlist

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -183,14 +183,19 @@ fn generate_handle(filename: &String) -> Option<LineWriter<File>>
 }
 
 // Prints out start up information
-pub fn startup_text(global_opts: Arc<GlobalOpts>) {
+pub fn startup_text(global_opts: Arc<GlobalOpts>, wordlist_file: &String) {
     if !global_opts.is_terminal { return }
 
     println!("Dirble {}", get_version_string());
     println!("Developed by Izzy Whistlecroft\n");
 
     println!("Targets: {}", global_opts.hostnames.clone().join(" "));
-    println!("Wordlists: {}", global_opts.wordlist_files.clone().join(" "));
+    if let Some(globalopts_wordlists) = global_opts.wordlist_files.clone() {
+        println!("Wordlists: {}", globalopts_wordlists.join(" "));
+    }
+    else {
+        println!("Wordlist: {}", wordlist_file);
+    }
 
     if global_opts.prefixes.len() == 1 && global_opts.prefixes[0] == "" {
         println!("No Prefixes");

--- a/src/wordlist.rs
+++ b/src/wordlist.rs
@@ -89,7 +89,7 @@ impl Iterator for UriGenerator {
 }
 
 // Function used to read in lines from the wordlist file
-pub fn lines_from_file(filename: String) -> Vec<String>
+pub fn lines_from_file(filename: &String) -> Vec<String>
 {
     let mut file = File::open(filename.clone())
         .unwrap_or_else(|error| { error!("Opening file \"{}\" failed: {}", filename, error); exit(2);});


### PR DESCRIPTION
Checks the following locations (in order) for the default wordlist when one is not specified on the command line:
* Directory containing the executable
* /usr/share/dirble/
* /usr/share/wordlists/
* /usr/share/wordlists/dirble/