### PR TITLE
Fix bug where multiple lines matching "version" were concatenated

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ cargo_flags = --release \
 
 # Get the version string out of the Cargo.toml by taking the second field
 # (delimited by double quotes) of the 'version = "x.y.z"' line
-version=$(shell awk -F'"' '/version/ {print $$2}' Cargo.toml)
+version=$(shell awk -F'"' '^/version/ {print $$2}' Cargo.toml)
 date=$(shell date +%Y%m%d)
 filename="dirble-${version}-${date}"
 


### PR DESCRIPTION
This resulted in the release zips having an extraneous "1.0" in their names.