### PR TITLE
Bumped dependencies and resolved issues related to that

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,13 +3,10 @@
 version = 3
 
 [[package]]
-name = "ansi_term"
-version = "0.11.0"
+name = "anyhow"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi",
-]
+checksum = "a26fa4d7e3f2eebadf743988fc8aec9fa9a9e82611acafd77c1462ed6262440a"
 
 [[package]]
 name = "atty"
@@ -54,6 +51,9 @@ name = "cc"
 version = "1.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9a06fb2e53271d7c279ec1efea6ab691c35a2ae67ec0d91d7acec0caf13b518"
+dependencies = [
+ "jobserver",
+]
 
 [[package]]
 name = "cfg-if"
@@ -74,29 +74,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a48563284b67c003ba0fb7243c87fab68885e1532c605704228a80238512e31"
 
 [[package]]
-name = "chrono"
-version = "0.4.13"
+name = "clap"
+version = "3.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c74d84029116787153e02106bf53e66828452a4b325cc8652b788b5967c0a0b6"
+checksum = "68d43934757334b5c0519ff882e1ab9647ac0258b47c24c4f490d78e42697fd5"
 dependencies = [
- "num-integer",
- "num-traits",
- "time",
+ "atty",
+ "bitflags",
+ "clap_lex",
+ "indexmap",
+ "once_cell",
+ "strsim",
+ "termcolor",
+ "textwrap",
 ]
 
 [[package]]
-name = "clap"
-version = "2.33.1"
+name = "clap_lex"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdfa80d47f954d53a35a64987ca1422f495b8d6483c0fe9f7117b36c2a792129"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
 dependencies = [
- "ansi_term",
- "atty",
- "bitflags",
- "strsim",
- "textwrap",
- "unicode-width",
- "vec_map",
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -109,6 +108,12 @@ dependencies = [
  "lazy_static",
  "winapi",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "ctrlc"
@@ -152,7 +157,7 @@ dependencies = [
 
 [[package]]
 name = "dirble"
-version = "1.4.2"
+version = "1.4.3"
 dependencies = [
  "atty",
  "chardet",
@@ -163,7 +168,7 @@ dependencies = [
  "encoding",
  "log",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "select",
  "serde",
  "serde_json",
@@ -171,6 +176,7 @@ dependencies = [
  "simple_xml_serialize",
  "simple_xml_serialize_macro",
  "simplelog",
+ "time 0.3.14",
  "url",
  "vergen",
 ]
@@ -240,6 +246,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a246d82be1c9d791c5dfde9a2bd045fc3cbba3fa2b11ad558f27d01712f00569"
 
 [[package]]
+name = "enum-iterator"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45a0ac4aeb3a18f92eaf09c6bb9b3ac30ff61ca95514fc58cbead1c9a6bf5401"
+dependencies = [
+ "enum-iterator-derive",
+]
+
+[[package]]
+name = "enum-iterator-derive"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "828de45d0ca18782232dfb8f3ea9cc428e8ced380eb26a520baaacfc70de39ce"
+dependencies = [
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
+]
+
+[[package]]
 name = "futf"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -257,8 +283,50 @@ checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
  "cfg-if 0.1.10",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
 ]
+
+[[package]]
+name = "getrandom"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getset"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
+]
+
+[[package]]
+name = "git2"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0155506aab710a86160ddb504a480d2964d7ab5b9e62419be69e0032bc5931c"
+dependencies = [
+ "bitflags",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hermit-abi"
@@ -278,9 +346,9 @@ dependencies = [
  "log",
  "mac",
  "markup5ever",
- "proc-macro2 1.0.18",
- "quote 1.0.7",
- "syn 1.0.34",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -295,10 +363,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
+dependencies = [
+ "autocfg",
+ "hashbrown",
+]
+
+[[package]]
 name = "itoa"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc6f3ad7b9d11a0c00842ff8de1b60ee58661048eb8049ed33c73594f359d7e6"
+
+[[package]]
+name = "itoa"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8af84674fe1f223a982c933a0ee1086ac4d4052aa0fb8060c12c6ad838e754"
+
+[[package]]
+name = "jobserver"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "lazy_static"
@@ -308,15 +401,27 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.72"
+version = "0.2.132"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9f8082297d534141b30c8d39e9b1773713ab50fdbe4ff30f750d063b3bfd701"
+checksum = "8371e4e5341c3a96db127eb2465ac681ced4c433e01dd0e938adbef26ba93ba5"
+
+[[package]]
+name = "libgit2-sys"
+version = "0.13.4+1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0fa6563431ede25f5cc7f6d803c6afbc1c5d3ad3d4925d12c882bf2b526f5d1"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
 
 [[package]]
 name = "libz-sys"
-version = "1.0.25"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2eb5e43362e38e2bca2fd5f5134c4d4564a23a5c28e9b95411652021a8675ebe"
+checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
 dependencies = [
  "cc",
  "libc",
@@ -394,23 +499,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-integer"
-version = "0.1.43"
+name = "ntapi"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d59457e662d541ba17869cf51cf177c0b5f0cbf476c66bdc90bf1edac4f875b"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
 dependencies = [
- "autocfg",
- "num-traits",
+ "winapi",
 ]
 
 [[package]]
-name = "num-traits"
-version = "0.2.12"
+name = "num_threads"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac267bcc07f48ee5f8935ab0d24f316fb722d7a1292e2913f0cc196b29ffd611"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
 dependencies = [
- "autocfg",
+ "libc",
 ]
+
+[[package]]
+name = "once_cell"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "074864da206b4973b84eb91683020dbefd6a8c3f0f38e054d93954e891935e4e"
 
 [[package]]
 name = "openssl-probe"
@@ -430,6 +540,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
 
 [[package]]
 name = "percent-encoding"
@@ -463,7 +579,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.7.3",
 ]
 
 [[package]]
@@ -494,21 +610,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 dependencies = [
- "unicode-xid 0.1.0",
+ "unicode-xid",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.18"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beae6331a816b1f65d04c45b078fd8e6c93e8071771f41b8163255bbd8d7c8fa"
+checksum = "0a2ca2c61bc9f3d74d2886294ab7b9853abd9c1ad903a3ac7815c58989bb7bab"
 dependencies = [
- "unicode-xid 0.2.1",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -522,11 +662,11 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.7"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
+checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
- "proc-macro2 1.0.18",
+ "proc-macro2 1.0.43",
 ]
 
 [[package]]
@@ -535,12 +675,23 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.14",
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
  "rand_hc",
  "rand_pcg",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -550,7 +701,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.3",
 ]
 
 [[package]]
@@ -559,7 +720,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.14",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
+dependencies = [
+ "getrandom 0.2.7",
 ]
 
 [[package]]
@@ -568,7 +738,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -577,8 +747,23 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
 ]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97477e48b4cf8603ad5f7aaf897467cf42ab4218a38ef76fb14c2d6773a6d6a8"
 
 [[package]]
 name = "ryu"
@@ -608,6 +793,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93f6841e709003d68bb2deee8c343572bf446003ec20a583e76f7b15cebf3711"
+
+[[package]]
 name = "serde"
 version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -622,9 +813,9 @@ version = "1.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0be94b04690fbaed37cddffc5c134bf537c8e3329d53e982fe04c374978f8e"
 dependencies = [
- "proc-macro2 1.0.18",
- "quote 1.0.7",
- "syn 1.0.34",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -633,7 +824,7 @@ version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3433e879a558dde8b5e8feb2a04899cf34fdde1fafb894687e52105fc1162ac3"
 dependencies = [
- "itoa",
+ "itoa 0.4.6",
  "ryu",
  "serde",
 ]
@@ -649,15 +840,15 @@ dependencies = [
 
 [[package]]
 name = "simple_xml_serialize"
-version = "0.2.3"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "faddd1c2725904a26968bd0948be212e368c86dd0feecb5ab92ec6ddd4a85955"
+checksum = "2f8896c3696f051907ae5e59f0c2d9fb9f7521c29d636e4a1ea4ff0e4e5aac15"
 
 [[package]]
 name = "simple_xml_serialize_macro"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c88083b952d9e4efa3d2bdf6d95ba6acdbbdd72e160d72b2b63a5d29bf3098"
+checksum = "9bb5b2d529bb43b48ba8397e50d87e84d7d62455e48a8c18c304a5ab1a99d6e1"
 dependencies = [
  "quote 0.6.13",
  "syn 0.15.44",
@@ -665,13 +856,13 @@ dependencies = [
 
 [[package]]
 name = "simplelog"
-version = "0.8.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b2736f58087298a448859961d3f4a0850b832e72619d75adc69da7993c2cd3c"
+checksum = "48dfff04aade74dd495b007c831cd6f4e0cee19c344dd9dc0884c0289b70a786"
 dependencies = [
- "chrono",
  "log",
  "termcolor",
+ "time 0.3.14",
 ]
 
 [[package]]
@@ -712,15 +903,15 @@ checksum = "f24c8e5e19d22a726626f1a5e16fe15b132dcf21d10177fa5a45ce7962996b97"
 dependencies = [
  "phf_generator",
  "phf_shared",
- "proc-macro2 1.0.18",
- "quote 1.0.7",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
 ]
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -730,18 +921,32 @@ checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 dependencies = [
  "proc-macro2 0.4.30",
  "quote 0.6.13",
- "unicode-xid 0.1.0",
+ "unicode-xid",
 ]
 
 [[package]]
 name = "syn"
-version = "1.0.34"
+version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "936cae2873c940d92e697597c5eee105fb570cd5689c695806f672883653349b"
+checksum = "58dbef6ec655055e20b86b15a8cc6d439cca19b667537ac6a1369572d151ab13"
 dependencies = [
- "proc-macro2 1.0.18",
- "quote 1.0.7",
- "unicode-xid 0.2.1",
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "unicode-ident",
+]
+
+[[package]]
+name = "sysinfo"
+version = "0.26.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "621609553b14bca49448b3c97e625d7187980cc2a42fd169b4c3b306dcc4a7e9"
+dependencies = [
+ "cfg-if 1.0.0",
+ "core-foundation-sys",
+ "libc",
+ "ntapi",
+ "once_cell",
+ "winapi",
 ]
 
 [[package]]
@@ -757,20 +962,37 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.0"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6bfa289a4d7c5766392812c0a1f4c1ba45afa1ad47803c11e1f407d846d75f"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+
+[[package]]
+name = "thiserror"
+version = "1.0.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d0a539a918745651435ac7db7a18761589a94cd7e94cd56999f828bf73c8a57"
 dependencies = [
- "unicode-width",
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c251e90f708e16c49a16f4917dc2131e75222b72edfa9cb7f7c58ae56aae0c09"
+dependencies = [
+ "proc-macro2 1.0.43",
+ "quote 1.0.21",
+ "syn 1.0.99",
 ]
 
 [[package]]
@@ -782,6 +1004,24 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3f9a28b618c3a6b9251b6908e9c99e04b9e5c02e6581ccbb67d59c34ef7f9b"
+dependencies = [
+ "itoa 1.0.3",
+ "libc",
+ "num_threads",
+ "time-macros",
+]
+
+[[package]]
+name = "time-macros"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
 
 [[package]]
 name = "tinyvec"
@@ -799,6 +1039,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-ident"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4f5b37a154999a8f3f98cc23a628d850e154479cd94decf3414696e12e31aaf"
+
+[[package]]
 name = "unicode-normalization"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -808,22 +1054,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-width"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
-
-[[package]]
 name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7fe0bb3479651439c9112f72b6c505038574c9fbb575ed1bf3b797fa39dd564"
 
 [[package]]
 name = "url"
@@ -849,20 +1083,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6454029bf181f092ad1b853286f23e2c507d8e8194d01d92da4a55c274a5508c"
 
 [[package]]
-name = "vec_map"
-version = "0.8.2"
+name = "vergen"
+version = "7.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+checksum = "73ba753d713ec3844652ad2cb7eb56bc71e34213a14faddac7852a10ba88f61e"
+dependencies = [
+ "anyhow",
+ "cfg-if 1.0.0",
+ "enum-iterator",
+ "getset",
+ "git2",
+ "rustc_version",
+ "rustversion",
+ "sysinfo",
+ "thiserror",
+ "time 0.3.14",
+]
 
 [[package]]
-name = "vergen"
-version = "3.1.0"
+name = "version_check"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce50d8996df1f85af15f2cd8d33daae6e479575123ef4314a51a70a230739cb"
-dependencies = [
- "bitflags",
- "chrono",
-]
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "void"
@@ -875,6 +1117,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"
@@ -916,5 +1164,5 @@ dependencies = [
  "log",
  "mac",
  "markup5ever",
- "time",
+ "time 0.1.43",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dirble"
-version = "1.4.2"
+version = "1.4.3"
 authors = ["Izzy Whistlecroft <izzy.whistlecroft@nccgroup.com>"]
 edition = "2018"
 build = "build.rs"
@@ -9,25 +9,26 @@ license = "GPL-3-or-later"
 [dependencies]
 curl = "0.4.19"
 percent-encoding = "2.1"
-clap = "2.32"
+clap = { version = "3.1.18", features = ["cargo"] }
 select = "0.5"
 chardet = "0.2.4"
 encoding = "0.2.33"
 atty = "0.2.11"
 colored = "2.0"
-rand = "0.7"
+rand = "0.8.5"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serde_test = "1.0"
-simple_xml_serialize = "0.2.1"
-simple_xml_serialize_macro = "0.2.1"
+simple_xml_serialize = "0.3.0"
+simple_xml_serialize_macro = "0.3.0"
 log = "0.4.6"
-simplelog = "0.8.0"
+simplelog = "0.12.0"
 ctrlc = "3.0"
 url = "2.1"
+time = "0.3.14"
 
 [build-dependencies]
-vergen = "3"
+vergen = "7.4.2"
 
 [features]
 release_version_string = []

--- a/build.rs
+++ b/build.rs
@@ -1,9 +1,9 @@
-use vergen::{generate_cargo_keys, ConstantsFlags};
+use vergen::{Config, ShaKind, TimestampKind};
 
 fn main() {
-    let mut flags = ConstantsFlags::all();
-    flags.toggle(ConstantsFlags::SEMVER_FROM_CARGO_PKG);
+    let mut config = Config::default();
+    *config.git_mut().sha_kind_mut() = ShaKind::Short;
+    *config.build_mut().kind_mut() = TimestampKind::DateOnly;
 
-    generate_cargo_keys(ConstantsFlags::all())
-        .expect("Unable to generate Cargo env keys");
+    vergen::vergen(config).expect("Couldn't generate keys");
 }

--- a/src/arg_parse.rs
+++ b/src/arg_parse.rs
@@ -199,7 +199,7 @@ http://user:pass@host:port")
              .long("uri")
              .multiple(true)
              .next_line_help(true)
-             .short("u")
+             .short('u')
              .takes_value(true)
              .validator(url_is_valid)
              .value_name("uri")
@@ -213,7 +213,7 @@ headers set will be applied to all URIs")
              .long("uri-file")
              .multiple(true)
              .next_line_help(true)
-             .short("U")
+             .short('U')
              .takes_value(true)
              .value_name("uri-file")
              .visible_alias("url-file"))
@@ -239,7 +239,7 @@ folder as the executable")
              .long("wordlist")
              .multiple(true)
              .next_line_help(true)
-             .short("w")
+             .short('w')
              .takes_value(true)
              .value_name("wordlist"))
         .arg(Arg::with_name("extensions")
@@ -250,8 +250,8 @@ folder as the executable")
              .min_values(1)
              .multiple(true)
              .next_line_help(true)
-             .short("x")
-             .value_delimiter(",")
+             .short('x')
+             .value_delimiter(',')
              .value_name("extensions"))
         .arg(Arg::with_name("extension_file")
              .display_order(30)
@@ -261,7 +261,7 @@ per line")
              .long("extension-file")
              .multiple(true)
              .next_line_help(true)
-             .short("X")
+             .short('X')
              .value_name("extension-file"))
         .group(ArgGroup::with_name("extension-options")
                .args(&["extensions", "extension_file"])
@@ -277,7 +277,7 @@ substituted with the current extension")
             .display_order(31)
             .help("Only scan with provided extensions")
             .requires("extension-options")
-            .short("f")
+            .short('f')
             .long("force-extension"))
         .arg(Arg::with_name("prefixes")
              .display_order(30)
@@ -287,8 +287,8 @@ substituted with the current extension")
              .min_values(1)
              .multiple(true)
              .next_line_help(true)
-             .short("p")
-             .value_delimiter(","))
+             .short('p')
+             .value_delimiter(','))
         .arg(Arg::with_name("prefix_file")
              .display_order(30)
              .help(
@@ -297,7 +297,7 @@ per line")
              .long("prefix-file")
              .multiple(true)
              .next_line_help(true)
-             .short("P")
+             .short('P')
              .value_name("prefix-file"))
         .arg(Arg::with_name("output_file")
              .display_order(40)
@@ -305,7 +305,7 @@ per line")
 "Sets the file to write the report to")
              .long("output-file")
              .next_line_help(true)
-             .short("o")
+             .short('o')
              .takes_value(true)
              .visible_alias("oN"))
         .arg(Arg::with_name("json_file")
@@ -365,7 +365,7 @@ username and password in the form
 "Sets the maximum number of request threads that will be spawned")
              .long("max-threads")
              .next_line_help(true)
-             .short("t")
+             .short('t')
              .takes_value(true)
              .validator(positive_int_check)
              .value_name("max-threads"))
@@ -376,7 +376,7 @@ username and password in the form
 "The number of threads to run for each folder/extension combo")
              .long("wordlist-split")
              .next_line_help(true)
-             .short("T")
+             .short('T')
              .validator(positive_int_check))
         .arg(Arg::with_name("throttle")
              .display_order(61)
@@ -384,7 +384,7 @@ username and password in the form
 "Time each thread will wait between requests, given in milliseconds")
              .long("throttle")
              .next_line_help(true)
-             .short("z")
+             .short('z')
              .takes_value(true)
              .validator(positive_int_check)
              .value_name("milliseconds"))
@@ -410,7 +410,7 @@ username and password in the form
 "Disable discovered subdirectory scanning")
              .long("disable-recursion")
              .next_line_help(true)
-             .short("r"))
+             .short('r'))
         .arg(Arg::with_name("max_recursion_depth")
              .display_order(80)
              .help(
@@ -426,7 +426,7 @@ recursion")
 "Scan listable directories")
              .long("scan-listable")
              .next_line_help(true)
-             .short("l")
+             .short('l')
              .takes_value(false))
         .arg(Arg::with_name("scrape_listable")
              .display_order(80)
@@ -443,7 +443,7 @@ amounts of output")
              .long("cookie")
              .multiple(true)
              .next_line_help(true)
-             .short("c")
+             .short('c')
              .takes_value(true))
         .arg(Arg::with_name("header")
              .display_order(90)
@@ -453,7 +453,7 @@ no value must end in a semicolon")
              .long("header")
              .multiple(true)
              .next_line_help(true)
-             .short("H")
+             .short('H')
              .takes_value(true))
         .arg(Arg::with_name("user_agent")
              .display_order(90)
@@ -461,7 +461,7 @@ no value must end in a semicolon")
 "Set the user-agent provided with requests, by default it isn't set")
              .long("user-agent")
              .next_line_help(true)
-             .short("a")
+             .short('a')
              .takes_value(true))
         .arg(Arg::with_name("verbose")
              .display_order(100)
@@ -470,7 +470,7 @@ no value must end in a semicolon")
              .long("verbose")
              .multiple(true)
              .next_line_help(true)
-             .short("v")
+             .short('v')
              .takes_value(false)
              .conflicts_with("silent"))
         .arg(Arg::with_name("silent")
@@ -480,7 +480,7 @@ no value must end in a semicolon")
 the end.")
              .long("silent")
              .next_line_help(true)
-             .short("S")
+             .short('S')
              .takes_value(false))
         .arg(Arg::with_name("code_whitelist")
              .display_order(110)
@@ -491,9 +491,9 @@ also disables detection of not found codes")
              .min_values(1)
              .multiple(true)
              .next_line_help(true)
-             .short("W")
+             .short('W')
              .validator(positive_int_check)
-             .value_delimiter(","))
+             .value_delimiter(','))
         .arg(Arg::with_name("code_blacklist")
              .conflicts_with("code_whitelist")
              .display_order(110)
@@ -503,9 +503,9 @@ also disables detection of not found codes")
              .min_values(1)
              .multiple(true)
              .next_line_help(true)
-             .short("B")
+             .short('B')
              .validator(positive_int_check)
-             .value_delimiter(","))
+             .value_delimiter(','))
         .arg(Arg::with_name("disable_validator")
              .display_order(110)
              .help(
@@ -529,7 +529,7 @@ also disables detection of not found codes")
              .help(
 "Ignore the certificate validity for HTTPS")
              .long("ignore-cert")
-             .short("k"))
+             .short('k'))
         .arg(Arg::with_name("show_htaccess")
              .help(
 "Enable display of items containing .ht when they return 403 responses")
@@ -563,7 +563,7 @@ set to 0 to disable")
              .multiple(true)
              .next_line_help(true)
              .takes_value(true)
-             .value_delimiter(","))
+             .value_delimiter(','))
         .get_matches();
 
     let mut hostnames: Vec<Url> = Vec::new();
@@ -580,7 +580,7 @@ set to 0 to disable")
         for host_file in host_files {
             let hosts = lines_from_file(&String::from(host_file));
             for hostname in hosts {
-                if url_is_valid(hostname.clone()).is_ok() {
+                if url_is_valid(hostname.as_str()).is_ok() {
                     if let Ok(host) = Url::parse(hostname.as_str()) {
                         hostnames.push(host);
                     }
@@ -882,14 +882,14 @@ fn load_modifiers(args: &clap::ArgMatches, mod_type: &str) -> Vec<String> {
 #[inline]
 pub fn get_version_string() -> &'static str {
     if cfg!(feature = "release_version_string")
-        || env!("VERGEN_SHA_SHORT") == "UNKNOWN"
+        || env!("VERGEN_GIT_SHA_SHORT") == "UNKNOWN"
     {
         return crate_version!();
     } else {
         return concat!(
             crate_version!(),
             " (commit ",
-            env!("VERGEN_SHA_SHORT"),
+            env!("VERGEN_GIT_SHA_SHORT"),
             ", build ",
             env!("VERGEN_BUILD_DATE"),
             ")"
@@ -897,8 +897,8 @@ pub fn get_version_string() -> &'static str {
     }
 }
 
-fn url_is_valid(hostname: String) -> Result<(), String> {
-    let url = Url::parse(hostname.as_str());
+fn url_is_valid(hostname: &str) -> Result<(), String> {
+    let url = Url::parse(hostname);
     if let Ok(u) = url {
         if u.scheme() == "http" || u.scheme() == "https" {
             Ok(())
@@ -912,7 +912,7 @@ fn url_is_valid(hostname: String) -> Result<(), String> {
 
 // Validator for arguments including the --max-threads flag
 // Ensures that the value is a positive integer (not 0)
-fn positive_int_check(value: String) -> Result<(), String> {
+fn positive_int_check(value: &str) -> Result<(), String> {
     let int_val = value.parse::<u32>();
     if let Ok(max) = int_val {
         if max > 0 {
@@ -924,7 +924,7 @@ fn positive_int_check(value: String) -> Result<(), String> {
 
 // Validator for various arguments, ensures that value is a
 // positive integer, including 0
-fn int_check(value: String) -> Result<(), String> {
+fn int_check(value: &str) -> Result<(), String> {
     let int_val = value.parse::<u32>();
     match int_val {
         Ok(_) => Ok(()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -52,7 +52,6 @@ fn main() {
     // connected to a TTY) then set up a SimpleLogger instead.
     let log_config = simplelog::ConfigBuilder::new()
         .set_time_level(LevelFilter::Debug)
-        .set_time_format_rfc2822()
         .set_time_format_custom(format_description!("[hour]:[minute]:[second]"))
         .build();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@
 
 use log::LevelFilter;
 use log::{debug, error, info, warn};
-use simplelog::{TermLogger, TerminalMode};
+use simplelog::{format_description, ColorChoice, TermLogger, TerminalMode};
 use std::{
     collections::VecDeque,
     env::current_exe,
@@ -52,12 +52,18 @@ fn main() {
     // connected to a TTY) then set up a SimpleLogger instead.
     let log_config = simplelog::ConfigBuilder::new()
         .set_time_level(LevelFilter::Debug)
-        .set_time_format("%T".to_string())
+        .set_time_format_rfc2822()
+        .set_time_format_custom(format_description!("[hour]:[minute]:[second]"))
         .build();
 
     // TermLogger::init() fails only if another Logger was initialised
-    TermLogger::init(global_opts.log_level, log_config, TerminalMode::Mixed)
-        .expect("Failed to init TermLogger");
+    TermLogger::init(
+        global_opts.log_level,
+        log_config,
+        TerminalMode::Mixed,
+        ColorChoice::Auto,
+    )
+    .expect("Failed to init TermLogger");
 
     // Get the wordlist file from the arguments. If it has not been set
     // then try the default wordlist locations.
@@ -333,7 +339,7 @@ fn add_dir_to_scan_queue(
     // improve performance of the initial discovery phase.
     let num_hosts = global_opts.hostnames.len() as u32;
     let wordlist_split;
-    if first_run 
+    if first_run
         && global_opts.max_threads >= 3
         && (global_opts.wordlist_split * num_hosts)
             < (global_opts.max_threads - 2)

--- a/src/validator_thread.rs
+++ b/src/validator_thread.rs
@@ -18,12 +18,13 @@
 use crate::arg_parse;
 use crate::request;
 use curl::easy::Easy2;
+use rand::distributions::DistString;
 use std::collections::HashSet;
 use std::fmt;
 use std::sync::{mpsc, Arc};
 
 use rand::distributions::Alphanumeric;
-use rand::{thread_rng, Rng};
+use rand::thread_rng;
 
 use log::{debug, info, warn};
 use url::Url;
@@ -415,8 +416,5 @@ fn determine_not_found(
 // Based on https://rust-lang-nursery.github.io/rust-cookbook/algorithms/randomness.html
 // Generates a string of alphanumeric characters of the given length
 fn rand_string(length: usize) -> String {
-    thread_rng()
-        .sample_iter(&Alphanumeric)
-        .take(length)
-        .collect()
+    Alphanumeric.sample_string(&mut thread_rng(), length)
 }


### PR DESCRIPTION
Just bumped the current versions of dependencies and resolved any issues between versions.

- Clap 
  - Changes to short and value delimiters from strings to chars
  - Validators take &str now
- rand - changed random string generation method
- simple_xml_serialize - no changes required
- simple_log
  - termlogger requires colour enum during creation
  - required adding time crate for custom time stamp
- vergen 
  - Changed method for creation of keys
  - Changed some env variable names