### PR TITLE
Apply various clippy fixes

### DIFF
--- a/src/arg_parse.rs
+++ b/src/arg_parse.rs
@@ -89,7 +89,7 @@ impl fmt::Debug for LengthRange {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct LengthRanges {
     pub ranges: Vec<LengthRange>,
 }
@@ -106,12 +106,6 @@ impl LengthRanges {
 
     pub fn is_empty(&self) -> bool {
         self.ranges.is_empty()
-    }
-}
-
-impl Default for LengthRanges {
-    fn default() -> Self {
-        Self { ranges: Vec::new() }
     }
 }
 
@@ -734,23 +728,11 @@ set to 0 to disable")
             0
         },
         max_recursion_depth,
-        user_agent: if let Some(user_agent) = args.value_of("user_agent") {
-            Some(String::from(user_agent))
-        } else {
-            None
-        },
+        user_agent: args.value_of("user_agent").map(String::from),
         // Dependency between username and password is handled by Clap
-        username: if let Some(username) = args.value_of("username") {
-            Some(String::from(username))
-        } else {
-            None
-        },
+        username: args.value_of("username").map(String::from),
         // Dependency between username and password is handled by Clap
-        password: if let Some(password) = args.value_of("password") {
-            Some(String::from(password))
-        } else {
-            None
-        },
+        password: args.value_of("password").map(String::from),
         output_file: filename_from_args(&args, FileTypes::Txt),
         json_file: filename_from_args(&args, FileTypes::Json),
         xml_file: filename_from_args(&args, FileTypes::Xml),
@@ -824,11 +806,8 @@ fn filename_from_args(
         }
     }
 
-    if let Some(output_all_prefix) = args.value_of("output_all") {
-        Some(format!("{}.{}", output_all_prefix, extension))
-    } else {
-        None
-    }
+    args.value_of("output_all")
+        .map(|output_all_prefix| format!("{}.{}", output_all_prefix, extension))
 }
 
 #[inline]
@@ -884,16 +863,16 @@ pub fn get_version_string() -> &'static str {
     if cfg!(feature = "release_version_string")
         || env!("VERGEN_SHA_SHORT") == "UNKNOWN"
     {
-        return crate_version!();
+        crate_version!()
     } else {
-        return concat!(
+        concat!(
             crate_version!(),
             " (commit ",
             env!("VERGEN_SHA_SHORT"),
             ", build ",
             env!("VERGEN_BUILD_DATE"),
             ")"
-        );
+        )
     }
 }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -47,16 +47,16 @@ pub fn print_response(
 
     let mut output = String::new();
     output += &output_format::output_indentation(
-        &response,
+        response,
         print_newlines,
         indentation,
     );
 
-    output += &output_format::output_letter(&response);
+    output += &output_format::output_letter(response);
 
-    output += &output_format::output_url(&response);
+    output += &output_format::output_url(response);
 
-    output += &output_format::output_suffix(&response, colour);
+    output += &output_format::output_suffix(response, colour);
 
     Some(output)
 }
@@ -68,9 +68,9 @@ pub fn print_report(
     global_opts: Arc<GlobalOpts>,
     file_handles: FileHandles,
 ) {
-    for mut response_list in &mut responses {
+    for response_list in &mut responses {
         //*response_list =
-        sort_responses(&mut response_list);
+        sort_responses(response_list);
     }
 
     // If stdout is a terminal then write a report to it
@@ -82,7 +82,7 @@ pub fn print_report(
             );
             for response in response_list {
                 if let Some(line) = print_response(
-                    &response,
+                    response,
                     global_opts.clone(),
                     true,
                     true,
@@ -104,7 +104,7 @@ pub fn print_report(
             write_file(&mut handle, report_string);
             for response in response_list {
                 if let Some(line) = print_response(
-                    &response,
+                    response,
                     global_opts.clone(),
                     true,
                     false,
@@ -170,10 +170,10 @@ fn write_file(file_writer: &mut LineWriter<File>, line: String) {
 
 // Sorts responses so that files in a directory come first, followed by
 // the subdirs
-pub fn sort_responses(responses: &mut Vec<RequestResponse>) {
+pub fn sort_responses(responses: &mut [RequestResponse]) {
     responses.sort_by(|a, b| {
-        directory_name(&a)
-            .cmp(&directory_name(&b))
+        directory_name(a)
+            .cmp(&directory_name(b))
             .then(a.url.cmp(&b.url))
     });
 }
@@ -223,7 +223,7 @@ pub fn create_files(global_opts: Arc<GlobalOpts>) -> FileHandles {
 #[inline]
 fn generate_handle(filename: &str) -> Option<LineWriter<File>> {
     let path = Path::new(&filename);
-    match File::create(&path) {
+    match File::create(path) {
         Err(why) => panic!("couldn't create {}: {}", path.display(), why),
         Ok(file) => Some(LineWriter::new(file)),
     }
@@ -259,19 +259,20 @@ pub fn startup_text(
         format!("{}Wordlist: {}\n", text, wordlist_file)
     };
 
-    let text =
-        if global_opts.prefixes.len() == 1 && global_opts.prefixes[0] == "" {
-            format!("{}No Prefixes\n", text)
-        } else {
-            format!(
-                "{}Prefixes: {}\n",
-                text,
-                global_opts.prefixes.clone()[1..].join(" ")
-            )
-        };
+    let text = if global_opts.prefixes.len() == 1
+        && global_opts.prefixes[0].is_empty()
+    {
+        format!("{}No Prefixes\n", text)
+    } else {
+        format!(
+            "{}Prefixes: {}\n",
+            text,
+            global_opts.prefixes.clone()[1..].join(" ")
+        )
+    };
 
     let text = if global_opts.extensions.len() == 1
-        && global_opts.extensions[0] == ""
+        && global_opts.extensions[0].is_empty()
     {
         format!("{}No Extensions\n", text)
     } else {

--- a/src/output_format.rs
+++ b/src/output_format.rs
@@ -94,7 +94,7 @@ pub fn output_suffix(response: &RequestResponse, color: bool) -> String {
 
 #[inline]
 pub fn output_xml(response: &RequestResponse) -> String {
-    format!("{}\n", XMLElement::from(response).to_string())
+    format!("{}\n", XMLElement::from(response))
 }
 
 #[inline]

--- a/src/request.rs
+++ b/src/request.rs
@@ -107,17 +107,14 @@ impl RequestResponse {
 // This function takes an instance of "Easy2", a base URL and a suffix
 // It then makes the request, if the response was not a 404
 // then it will return a RequestResponse struct
-pub fn make_request(
-    mut easy: &mut Easy2<Collector>,
-    url: Url,
-) -> RequestResponse {
+pub fn make_request(easy: &mut Easy2<Collector>, url: Url) -> RequestResponse {
     trace!("Requesting {}", url);
     // Set the url in the Easy2 instance
-    easy.url(&url.as_str()).unwrap();
+    easy.url(url.as_str()).unwrap();
 
     // Perform the request and check if it's empty
     // If it's empty then return a RequestResponse struct
-    match perform(&mut easy) {
+    match perform(easy) {
         Ok(_v) => {}
         Err(e) => {
             println!("Curl error after requesting {} : {}", url, e);
@@ -195,7 +192,7 @@ pub fn listable_check(
         dir_url += "/";
     }
     let mut response =
-        make_request(easy, Url::parse(&dir_url.as_str()).unwrap());
+        make_request(easy, Url::parse(dir_url.as_str()).unwrap());
     let content = get_content(easy).to_lowercase();
     let mut output_list: Vec<RequestResponse> = Vec::new();
 
@@ -262,7 +259,7 @@ pub fn listable_check(
                     depth -= 1;
                 }
 
-                depth -= parent_depth as i32;
+                depth -= parent_depth;
 
                 // If we've exceeded the max depth, add the url to the
                 // values to be returned

--- a/src/request_thread.rs
+++ b/src/request_thread.rs
@@ -148,7 +148,7 @@ fn send_response(
         output_tx.send(response).unwrap();
         return;
     }
-    if should_send_response(&global_opts, &response, &validator_opt) {
+    if should_send_response(global_opts, &response, validator_opt) {
         output_tx.send(response).unwrap();
     }
 }
@@ -180,7 +180,7 @@ pub fn should_send_response(
         return false;
     }
     if let Some(validator) = validator_opt {
-        if validator.is_not_found(&response) {
+        if validator.is_not_found(response) {
             trace!("[{}]: matches Not Found condition", response.url);
             return false;
         }

--- a/src/validator_thread.rs
+++ b/src/validator_thread.rs
@@ -164,7 +164,7 @@ impl TargetValidator {
         // This branch should never happen because this function should
         // only be used if scan_folder returned false
         else {
-            format!("")
+            String::new()
         }
     }
 }
@@ -180,22 +180,21 @@ pub enum ValidatorAlert {
 impl fmt::Display for ValidatorAlert {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            ValidatorAlert::Code401 =>{
+            ValidatorAlert::Code401 => {
                 write!(f,
                     "\n    Scanning of directories returning 401 is disabled.\n    \
                     Use the --scan-401 flag to scan this directory,\n    \
                     or provide a valid session token or credentials.")
-            },
+            }
             ValidatorAlert::Code403 => {
                 write!(f,
                     "\n    Scanning of directories returning 403 is disabled.\n    \
                     Use the --scan-403 flag to scan this directory,\n    \
                     or provide valid session token or credentials.")
-            },
+            }
             // Placeholder branch
             ValidatorAlert::RedirectToHTTPS => {
-                write!(f,
-                    "The directory redirected to HTTPS")
+                write!(f, "The directory redirected to HTTPS")
             }
         }
     }
@@ -385,7 +384,7 @@ fn determine_not_found(
     }
 
     let mut diff_response_size = None;
-    if response_size == None {
+    if response_size.is_none() {
         let diff_0 = ((responses[0].content_len as i32)
             - responses[0].url.as_str().len() as i32)
             .abs();


### PR DESCRIPTION
Apply cargo clippy and rust fmt recommendations.

There are 2 clippy suggestions left to apply:
1. Implementing default for HttpVerb - adding this broke the clap macro surrounding it. This is likely to need overhauling as part of updating Clap from 2 to 4
2. The variable `parent_index` is only used in recursion in the function `listable_check`